### PR TITLE
Add GitHub release workflow and badge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: build-and-release
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Configure Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Set version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/}"
+          echo "Using version: $VERSION"
+          sed -i "s/^LIB_VERSION=.*/LIB_VERSION=${VERSION}/" gradle.properties
+
+      - name: Build AAR
+        run: ./gradlew clean assembleRelease
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: app/build/outputs/aar/app-release.aar
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ORS Android Client
 
-[![](https://jitpack.io/v/Pygmalion69/ors-android-client.svg)](https://jitpack.io/#Pygmalion69/ors-android-client)
+[![JitPack](https://jitpack.io/v/Pygmalion69/ors-android-client.svg)](https://jitpack.io/#Pygmalion69/ors-android-client) [![Release](https://img.shields.io/github/v/release/Pygmalion69/ors-android-client)](https://github.com/Pygmalion69/ors-android-client/releases)
 
 Android client library for the [OpenRouteService](https://openrouteservice.org) APIs.
 


### PR DESCRIPTION
## Summary
- trigger release workflow on tag pushes and set library version from tag
- document release while keeping existing JitPack badge in README

------
https://chatgpt.com/codex/tasks/task_e_68c05dd51dc0832799268875afb95b84