### PR TITLE
Clarify language requirement in RouteHelper GPX KDoc

### DIFF
--- a/app/src/main/java/org/nitri/ors/helper/RouteHelper.kt
+++ b/app/src/main/java/org/nitri/ors/helper/RouteHelper.kt
@@ -51,7 +51,7 @@ class RouteHelper {
     }
 
     /**
-     * Retrieves a route as GPX for an arbitrary coordinate list.
+     * Retrieves a route as GPX for an arbitrary coordinate list, requiring a language code for localization.
      */
     suspend fun OrsClient.getRouteGpx(
         coordinates: List<List<Double>>,


### PR DESCRIPTION
## Summary
- clarify the KDoc for `getRouteGpx` to note the required language parameter when using arbitrary coordinate lists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa163c1cf083278faea7213516d0f6