### PR TITLE
Replace raw assertion in RouteHelperTest

### DIFF
--- a/app/src/test/java/org/nitri/ors/RouteHelperTest.kt
+++ b/app/src/test/java/org/nitri/ors/RouteHelperTest.kt
@@ -1,6 +1,7 @@
 package org.nitri.ors
 
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
@@ -51,7 +52,7 @@ class RouteHelperTest {
 
         val result = with(routeHelper) { client.getRoute(start, end, profile) }
 
-        assert(result == expectedResponse)
+        assertEquals(expectedResponse, result)
         verify(client).getRoute(Profile.DRIVING_CAR, expectedRequest)
     }
 }


### PR DESCRIPTION
## Summary
- replace the raw Kotlin `assert` call in `RouteHelperTest` with JUnit's `assertEquals`
- import the JUnit assertion helper to keep the test running regardless of assertion settings

------
https://chatgpt.com/codex/tasks/task_e_68fa17182b6083279eb2f11aaf5c882d