### PR TITLE
Add LIB_VERSION property to align publish version with tags

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+# Library version overridden during publishing
+LIB_VERSION=0.1.2


### PR DESCRIPTION
## Summary
- add a LIB_VERSION entry to gradle.properties so the GitHub publish workflow can update the library version from the tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fce4d9e6a48327bc2f298cbd7b3843