### PR TITLE
Add GPX elevation option to OrsClient

### DIFF
--- a/app/src/main/java/org/nitri/ors/OrsClient.kt
+++ b/app/src/main/java/org/nitri/ors/OrsClient.kt
@@ -70,6 +70,13 @@ interface OrsClient {
     /** Retrieves the route as GPX. */
     suspend fun getRouteGpx(profile: Profile, routeRequest: RouteRequest): String
 
+    /** Retrieves the route as GPX, optionally adding elevation data. */
+    suspend fun getRouteGpx(
+        profile: Profile,
+        routeRequest: RouteRequest,
+        includeElevation: Boolean
+    ): String
+
     /** Retrieves the route as GeoJSON feature collection. */
     suspend fun getRouteGeoJson(profile: Profile, routeRequest: RouteRequest): GeoJsonRouteResponse
 

--- a/app/src/main/java/org/nitri/ors/helper/RouteHelper.kt
+++ b/app/src/main/java/org/nitri/ors/helper/RouteHelper.kt
@@ -51,6 +51,24 @@ class RouteHelper {
     }
 
     /**
+     * Retrieves a route as GPX between two coordinates with optional elevation data.
+     */
+    suspend fun OrsClient.getRouteGpx(
+        start: Pair<Double, Double>,
+        end: Pair<Double, Double>,
+        profile: String,
+        includeElevation: Boolean
+    ): String {
+        val request = RouteRequest(
+            coordinates = listOf(
+                listOf(start.first, start.second),
+                listOf(end.first, end.second)
+            )
+        )
+        return getRouteGpx(profileFromKey(profile), request, includeElevation)
+    }
+
+    /**
      * Retrieves a route as GPX for an arbitrary coordinate list, requiring a language code for localization.
      */
     suspend fun OrsClient.getRouteGpx(
@@ -60,6 +78,19 @@ class RouteHelper {
     ): String {
         val request = RouteRequest(coordinates = coordinates, language = language)
         return getRouteGpx(profileFromKey(profile), request)
+    }
+
+    /**
+     * Retrieves a route as GPX for an arbitrary coordinate list with optional elevation data.
+     */
+    suspend fun OrsClient.getRouteGpx(
+        coordinates: List<List<Double>>,
+        language: String,
+        profile: String,
+        includeElevation: Boolean
+    ): String {
+        val request = RouteRequest(coordinates = coordinates, language = language)
+        return getRouteGpx(profileFromKey(profile), request, includeElevation)
     }
 
     /**

--- a/app/src/main/java/org/nitri/ors/internal/DefaultOrsClient.kt
+++ b/app/src/main/java/org/nitri/ors/internal/DefaultOrsClient.kt
@@ -51,6 +51,20 @@ class DefaultOrsClient(apiKey: String, context: Context) : OrsClient {
     }
 
     /** @inheritDoc */
+    override suspend fun getRouteGpx(
+        profile: Profile,
+        routeRequest: RouteRequest,
+        includeElevation: Boolean
+    ): String {
+        val resolvedRequest = if (includeElevation) {
+            routeRequest.copy(elevation = true)
+        } else {
+            routeRequest
+        }
+        return api.getRouteGpx(profile.key, resolvedRequest).body()?.string() ?: ""
+    }
+
+    /** @inheritDoc */
     override suspend fun getRouteGeoJson(
         profile: Profile,
         routeRequest: RouteRequest


### PR DESCRIPTION
### Motivation
- Provide a way to request GPX output that includes elevation data without changing existing API callers. 
- Make it easy to request elevation-enriched GPX from the client and helper layers. 

### Description
- Added an overload `suspend fun getRouteGpx(profile: Profile, routeRequest: RouteRequest, includeElevation: Boolean): String` to `OrsClient`. 
- Implemented the overload in `DefaultOrsClient` to set `routeRequest.elevation = true` when `includeElevation` is `true` and call the existing `api.getRouteGpx` endpoint. 
- Added convenience extension overloads in `RouteHelper` (`getRouteGpx` for start/end and for coordinate lists) that accept `includeElevation` and delegate to the new `OrsClient` overload. 

### Testing
- No automated tests were executed as part of this change. 
- Changes were limited to API surface and helper overloads and preserve existing `getRouteGpx` behavior for callers that do not opt into elevation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69579adb130883278379c2af68fadfd2)