### PR TITLE
ci: upgrade workflow actions for Node.js 24 transition

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Configure Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Set version from tag
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Configure Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Set version from tag
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
### Motivation
- GitHub Actions runners are deprecating Node.js 20 and moving to Node.js 24 as the default, so the workflows need action majors that are compatible with Node.js 24.

### Description
- Bumped `actions/checkout` from `@v4` to `@v6` in `.github/workflows/release.yml` and `.github/workflows/publish.yml`.
- Bumped `actions/setup-java` from `@v4` to `@v5` in both workflow files.
- Bumped `gradle/actions/setup-gradle` from `@v3` to `@v6` in both workflow files.

### Testing
- Ran `rg -n "actions/checkout|actions/setup-java|gradle/actions/setup-gradle" .github/workflows` to confirm the old versions were replaced, which succeeded.
- Inspected the file diffs with `git diff -- .github/workflows/release.yml .github/workflows/publish.yml` to verify only the action version lines changed, which succeeded.
- Printed the updated workflow files with `nl -ba .github/workflows/release.yml .github/workflows/publish.yml` to validate the final content, which matched expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09991f529c8327b1e302d4f4ae0b52)